### PR TITLE
Added the form and Ravi's email text to the roadmap landing page

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,5 +1,21 @@
 # Roadmaps
 
+Hello ONNX contributors and stakeholders,
+
+We are seeking your help to shape the direction of ONNX & create roadmap with shared future view for the timeframe (Jan'2023 to December'2023). To capture your ideas for future development of ONNX, you can submit your proposals using the form located [here](https://forms.microsoft.com/r/d2ZcPgzwSV)
+
+If you had submitted roadmap items in previous years, please revisit/gauge and do appropriate modification of item(s) in case there is still an ask for the ONNX feature, In case you are revisiting the roadmap items this year and there is some overlap from the request of previous years, be sure to flag whether your request was completed / partially-done / work in progress. See next section for links to the roadmap disussions of previous years.
+
+The proposals will be collected till January 24, 2023. Once the proposals have been entered, we will hold 6 sessions starting the week of February 6, 2023 for roadmap discussions alternating between Wednesday 9:00 am PST (Europe friendly) and Wednesday 5:00 pm PST (Asia friendly) to prioritize the roadmap items based on your suggestions.
+
+The result of the discussions analyzed based on impact assessments will be announced via slack channels & social media.
+Looking forward to receiving some great suggestions.
+
+Thanks,
+ONNX steering committee
+
+## Previous roadmap discussions
+
 Here are links to our prior year's roadmap discussions:
 * [Year 2021](2021.md),
 * [Year 2020](2020.md).


### PR DESCRIPTION
Added the form and Ravi's email text to the roadmap landing page.

The idea is to have the news link point to this page, where all the info is avail. Let me know if you have a better idea.

If you like it, once this one is in, another PR to the web page GitHub will link the announcement to that page.

Signed-off-by: Alexandre Eichenberger <alexe@us.ibm.com>