### PR TITLE
Add meeting notes for June 3, 2026

### DIFF
--- a/meeting-notes/2026/20260603.MD
+++ b/meeting-notes/2026/20260603.MD
@@ -14,7 +14,7 @@ Other attendees: Agnes So (Intel)
 
 Moderator: Rama
 
-*	Community Meetup: 
+# Community Meetup: 
 - The seven proposals for technical talks submitted were accepted
 - Discussed about an update presentation from the steering committee in meetup. Alex to look into this.
 - What are other candidates for the agenda?

--- a/meeting-notes/2026/20260603.MD
+++ b/meeting-notes/2026/20260603.MD
@@ -14,7 +14,7 @@ Other attendees: Agnes So (Intel)
 
 Moderator: Rama
 
-# Community Meetup: 
+### Community Meetup: 
 - The seven proposals for technical talks submitted were accepted
 - Discussed about an update presentation from the steering committee in meetup. Alex to look into this.
 - What are other candidates for the agenda?

--- a/meeting-notes/2026/20260603.MD
+++ b/meeting-notes/2026/20260603.MD
@@ -1,0 +1,31 @@
+##  Meeting 03 June 2026
+
+### Attendance:
+
+| Name (Affiliation)              | Present  |
+| ------------------------------- | -------- |
+| Alexandre Eichenberger (IBM)            | y |
+| Brian Nguyen (NVIDIA)                   | n |
+| Andreas Fehlner (TRUMPF Laser)          | y |
+| Ganesan Ramalingam ("Rama") (Microsoft) | y |
+| Javier Martinez (Intel)                 | y |
+
+Other attendees: Agnes So (Intel)
+
+Moderator: Rama
+
+*	Community Meetup: 
+- The seven proposals for technical talks submitted were accepted
+- Discussed about an update presentation from the steering committee in meetup. Alex to look into this.
+- What are other candidates for the agenda?
+  - Agnes suggested the topic of use of AI (agents) in ONNX repo
+  - Rama agreed that it was an interesting and useful topic
+  - TBD whether and in what form (panel discussion, free discussion, speakers?)
+  - Alex suggested that SONNX (the working group) could potentially present a full presentation,
+    instead of just an update. Rama agreed. Action item: to check with SONNX leads about this.
+  - Alex suggested that a longer update from GenAI and/or discussions about how to get onnx
+    versions of popular LLMs would be useful. One of the accepted talks (on Mobius) also covers
+    this topic.
+  - An update from Matt White (or some one) about ONNX becoming a foundation member of Pytorch
+    foundation? Andreas to check with Matt.
+  - Agnes also suggested that security was an interesting topic. (Nothing decided about this.)


### PR DESCRIPTION
Documented meeting notes for the community meetup held on June 3, 2026, including attendance and discussion points.